### PR TITLE
TypeError on error

### DIFF
--- a/python/seisma/client.py
+++ b/python/seisma/client.py
@@ -42,7 +42,7 @@ def will_expected(status_code):
                         getattr(
                             error, 'message',
                             u' '.join(
-                                i for i in getattr(error, 'args', []) if not isinstance(i, int)
+                                str(i) for i in getattr(error, 'args', []) if not isinstance(i, int)
                             )
                         ),
                     ),
@@ -73,7 +73,7 @@ def true_by_status(success_status_code):
                         getattr(
                             error, 'message',
                             u' '.join(
-                                i for i in getattr(error, 'args', []) if not isinstance(i, int)
+                                str(i) for i in getattr(error, 'args', []) if not isinstance(i, int)
                             )
                         ),
                     ),


### PR DESCRIPTION
`python test.py --seisma --seisma-url=http://127.0.0.1:1810
Seismograph is measuring:

E

Seismograph is reporting about reasons:

======================================================================
<seismograph.program.Program method_name=run stopped_on=start_context>
======================================================================
Traceback (most recent call last):
  File "/home/andreyc/.local/lib64/python2.7/site-packages/seismograph/program.py", line 202, in __run__
    with self.__context(self):
  File "/usr/lib64/python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "/home/andreyc/.local/lib64/python2.7/site-packages/seismograph/runnable.py", line 192, in __call__
    self.start_context(runnable)
  File "/home/andreyc/.local/lib64/python2.7/site-packages/seismograph/program.py", line 84, in start_context
    call_to_chain(self.layers, 'on_setup', program)
  File "/home/andreyc/.local/lib64/python2.7/site-packages/seismograph/utils/common.py", line 46, in call_to_chain
    getattr(obj, method_name)(*args, **kwargs)
  File "/home/andreyc/.local/lib64/python2.7/site-packages/seismograph/ext/seisma/layers.py", line 83, in on_setup
    if not self.client.job_exists():
  File "/home/andreyc/.local/lib64/python2.7/site-packages/seisma/client.py", line 76, in wrapped
    i for i in getattr(error, 'args', []) if not isinstance(i, int)
TypeError: sequence item 0: expected string or Unicode, MaxRetryError found

---------------------------------------------------------------
tests=1 failures=0 errors=1 skipped=0 successes=0 runtime=0.005`